### PR TITLE
Fix safari image stretch

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -37,8 +37,24 @@ h1 {
   margin-left: 200px;
 }
 
+.image-container {
+  // margin-left: 10px;
+  // margin-right: 10px;
+  overflow: hidden;
+}
+
 .card-image {
+  height: 100%;
+  width: 100%;
+  min-width: 100%;
   opacity: 0.85;
+  overflow: hidden;
+  // transition: transform .3s ease-in-out;
+}
+
+.card-image:hover {
+  opacity: 0.85;
+  // transform: scale(1.07);
 }
 
 .title-body {
@@ -47,9 +63,18 @@ h1 {
   justify-content: space-between;
 }
 
+.card-body {
+  margin-left: 0 !important;
+  padding-left: 0 !important;
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+}
+
 .card {
   border: 0px;
   border-radius: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
 @media(max-width: 1200px) {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -49,12 +49,12 @@
   min-width: 100%;
   opacity: 0.85;
   overflow: hidden;
-  // transition: transform .3s ease-in-out;
+  transition: transform .3s ease-in-out;
 }
 
 .card-image:hover {
   opacity: 0.85;
-  // transform: scale(1.07);
+  transform: scale(1.07);
 }
 
 .title-body {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -76,6 +76,10 @@
   padding-right: 20px;
 }
 
+.fa-bookmark {
+  font-size: 1.1rem;
+}
+
 @media(max-width: 1200px) {
   .cards {
     grid-template-columns: 1fr 1fr 1fr;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -38,9 +38,8 @@
 }
 
 .image-container {
-  // margin-left: 10px;
-  // margin-right: 10px;
   overflow: hidden;
+  border-radius: 3px;
 }
 
 .card-image {

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -25,7 +25,7 @@
             </h5>
             <p class="card-text"><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i></p>
           </div>
-          <p><i class="fa-regular fa-bookmark"></i> <i class="fa-regular fa-plus"></i></p>
+          <p><i class="fa-regular fa-bookmark"></i></p>
         </div>
         <%# <div style="height: 200px; width: 300px; background-position: center; background-repeat: no-repeat; background-size: cover; background-image: url('https://lonelyplanetimages.imgix.net/a/g/hi/t/a2aa48e66952bf8816898991072e32f5-macritchie-reservoir.jpg')">
         </div> %>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -37,14 +37,15 @@
           <p class="card-text"><i class="fa-regular fa-clock"></i></i>
           <% hour = (trail.duration / 60).to_i %>
           <% minutes = (trail.duration % 60).to_i %>
-          <% if minutes < 10 %>
-            <%= hour %>h0<%= minutes %>
+          <% if hour == 00 %>
+            <%= minutes %>m
+          <% elsif minutes < 10 %>
+            <%= hour %>h 0<%= minutes %>m
           <% else %>
-            <%= hour %>h<%= minutes %>
+            <%= hour %>h <%= minutes %>m
           <% end %>
           </p>
         </div>
       <% end %>
     <% end %>
   </div>
-

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -11,7 +11,9 @@
         </div>
         <%# <div style="height: 200px; width: 300px; background-position: center; background-repeat: no-repeat; background-size: cover; background-image: url('https://lonelyplanetimages.imgix.net/a/g/hi/t/a2aa48e66952bf8816898991072e32f5-macritchie-reservoir.jpg')">
         </div> %>
-        <img src="https://lonelyplanetimages.imgix.net/a/g/hi/t/a2aa48e66952bf8816898991072e32f5-macritchie-reservoir.jpg" alt="trail picture" class="rounded-3 mx-3 card-image">
+        <div class= "image-container">
+          <img src="https://lonelyplanetimages.imgix.net/a/g/hi/t/a2aa48e66952bf8816898991072e32f5-macritchie-reservoir.jpg" alt="trail picture" class="rounded-3 card-image">
+        </div>
         <div class="card-body">
           <p class="card-text"><i class="fa-solid fa-person-hiking"></i> <%= trail.difficulty %></p>
           <p class="card-text"><i class="fa-regular fa-clock"></i></i> <%= pluralize(trail.duration,"minutes") %> </p>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -9,7 +9,7 @@
   <%= submit_tag "Search", class: "btn btn-primary" %>
 <% end %>
 
-<h1> Find your next hike ...</h1>
+<h1 class="margin-title-lg"> Find your next hike ...</h1>
 
   <div class="cards">
     <% @trails.each do |trail| %>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -48,6 +48,8 @@
                   <% minutes = (@trail.duration % 60).to_i %>
                   <% if minutes == 0 %>
                     <%= pluralize(hour, "hour") %>
+                  <% elsif hour == 0 %>
+                    <%= pluralize(minutes, "minute") %>
                   <% elsif minutes < 10 %>
                     <%= pluralize(hour, "hour") %> 0<%= minutes %> minutes
                   <% else %>


### PR DESCRIPTION
- Fixed the grid in safari: I added width and height to image.
- Change to time: added m for minute sin index. If hour = 0, don't show hour
- Effect picture when hover
- Position header was deleted during the last merge/conflict. Re-added it
- Deleted the + (add to list): we can only add to list from show page
- Bookmark slightly bigger